### PR TITLE
支持多声卡存储

### DIFF
--- a/audio_writer.go
+++ b/audio_writer.go
@@ -76,13 +76,25 @@ func (info *AudioInfo) Update() *AudioInfo {
 	return v
 }
 
-func (info *AudioInfo) Apply() {
+func trySetProfile(profile string) error {
 	cards := ctx.GetCardList()
-	if len(cards) != 0 {
-		cards[0].SetProfile(info.ActiveProfile)
-		logger.Infof("SetProfile %v on %v\n", info.ActiveProfile, cards[0])
-	} else {
-		logger.Error("Can't find any cards")
+	for _, c := range cards {
+		for _, pf := range c.Profiles {
+			if pf.Name == profile {
+				c.SetProfile(profile)
+				logger.Infof("SetProfile %v on %v\n", profile, c)
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("Can't find any cards %v contain the profile %v", cards, profile)
+}
+
+func (info *AudioInfo) Apply() {
+	err := trySetProfile(info.ActiveProfile)
+	if err != nil {
+		logger.Error(err)
+		return
 	}
 
 	audioObj.SetDefaultSink(info.ActiveSink)

--- a/audio_writer.go
+++ b/audio_writer.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"dbus/com/deepin/daemon/audio"
-	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -80,6 +80,9 @@ func (info *AudioInfo) Apply() {
 	cards := ctx.GetCardList()
 	if len(cards) != 0 {
 		cards[0].SetProfile(info.ActiveProfile)
+		logger.Infof("SetProfile %v on %v\n", info.ActiveProfile, cards[0])
+	} else {
+		logger.Error("Can't find any cards")
 	}
 
 	audioObj.SetDefaultSink(info.ActiveSink)
@@ -123,7 +126,7 @@ func readConfig() (*AudioInfo, error) {
 	}
 
 	var reader = bytes.NewBuffer(content)
-	dec := gob.NewDecoder(reader)
+	dec := json.NewDecoder(reader)
 	var info AudioInfo
 	err = dec.Decode(&info)
 	if err != nil {
@@ -142,7 +145,7 @@ func saveConfig(info *AudioInfo) error {
 	defer locker.Unlock()
 
 	var writer bytes.Buffer
-	enc := gob.NewEncoder(&writer)
+	enc := json.NewEncoder(&writer)
 	err := enc.Encode(info)
 	if err != nil {
 		return err

--- a/audio_writer.go
+++ b/audio_writer.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	audioHelperFile = ".config/deepin_audio_helper.conf"
+	ConfigPath = "/home/deepin/.config/deepin_audio_helper.conf"
 
 	audioDest = "com.deepin.daemon.Audio"
 	audioPath = "/com/deepin/daemon/Audio"
@@ -128,8 +128,7 @@ func readConfig() (*AudioInfo, error) {
 	locker.Lock()
 	defer locker.Unlock()
 
-	var file = path.Join(os.Getenv("HOME"), audioHelperFile)
-	content, err := ioutil.ReadFile(file)
+	content, err := ioutil.ReadFile(ConfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -161,13 +160,12 @@ func saveConfig(info *AudioInfo) error {
 		return err
 	}
 
-	var file = path.Join(os.Getenv("HOME"), audioHelperFile)
-	err = os.MkdirAll(path.Dir(file), 0755)
+	err = os.MkdirAll(path.Dir(ConfigPath), 0755)
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(file, writer.Bytes(), 0644)
+	return ioutil.WriteFile(ConfigPath, writer.Bytes(), 0644)
 }
 
 func getCurrentAudioInfo() *AudioInfo {
@@ -229,26 +227,6 @@ func (info *AudioInfo) PrintAudioInfo() {
 	fmt.Println("Current audio info:", info)
 }
 
-func (info *AudioInfo) initProfile() bool {
-	// cards := ctx.GetCardList()
-	// if len(cards) == 0 {
-	// 	return false
-	// }
-
-	// profiles := cProfileInfos(cards[0].Profiles)
-	// if len(profiles) == 0 {
-	// 	return false
-	// }
-	// sort.Sort(profiles)
-	// if profiles[0].Name == info.ActiveProfile {
-	// 	return false
-	// }
-
-	// logger.Info("Init profile:", profiles[0].Name)
-	//cards[0].SetProfile(profiles[0].Name)
-	return true
-}
-
 func main() {
 	var err error
 	audioObj, err = audio.NewAudio(audioDest, audioPath)
@@ -261,7 +239,6 @@ func main() {
 	if err != nil {
 		logger.Warning("Read audio helper config failed:", err)
 		info = getCurrentAudioInfo()
-		//info.initProfile()
 		saveConfig(info)
 	} else {
 		info.Apply()


### PR DESCRIPTION
- 更改gob为json方便调试
- 将ActiveProfile string改为ActiveProfiles map[string]string 用来记录和恢复所有的声卡
- 去除initProfile的调用
- 将配置文件固定为/home/deepin/.config/deepin_audio_writer.conf

TODO:
1.  普通用户目前只需要读取，因此可以优化写入部分。目前通过文件权限控制让普通用户写入失败。
2.  之前普通用户文件在未知阶段有几率被覆盖成错误的信息。因为改成只有deepin用户变动后所以未处理此问题
